### PR TITLE
Fix unsanitized output of query into the title

### DIFF
--- a/scripts/views/search_view.js
+++ b/scripts/views/search_view.js
@@ -63,7 +63,7 @@
 
         var presenter = new BH.Presenters.SearchPresenter(this.model.toJSON());
         var properties = presenter.searchInfo();
-        this.$('.title').html(properties.title);
+        this.$('.title').text(properties.title);
         this.$('.visits_content').html('');
       }
     },


### PR DESCRIPTION
This pull request fixes a Cross-Site Scripting (XSS) vulnerability in the extension. The query of the URL is simply output without any escaping.

To try it out go to:

```
chrome-extension://blpnkmdkoapbdhpmemnaikpbhajknmdb/index.html#search/<marquee>injected</marquee>
```

The impact of the vulnerability is low due to two mitigations Chrome has (extension URLs cannot be opened directly and CSP disallows direct script execution). As both security mechanisms can be circumvented in some cases, I did this quick fix so everyone can sleep better ;-)